### PR TITLE
div open/close tags caused the HTML not to be rendered properly due t…

### DIFF
--- a/guides/blog-beginners-guide.html
+++ b/guides/blog-beginners-guide.html
@@ -297,29 +297,29 @@
         <xmp>
            <%= form_for @changeset, @action, fn f -> %>
               <%= if f.errors != [] do %>
-                < div class="alert alert-danger">
+                <div class="alert alert-danger">
                   <p>Oops, something went wrong! Please check the errors below:</p>
                   <ul>
                     <%= for {attr, message} <- f.errors do %>
                       <li><%= humanize(attr) %> <%= message %></li>
                     <% end %>
                   </ul>
-                < /div>
+                </div>
               <% end %>
 
-              < div class="form-group">
+              <div class="form-group">
                 <label>Name</label>
                 <%= text_input f, :name, class: "form-control" %>
-              < /div>
+              </div>
 
-              < div class="form-group">
+              <div class="form-group">
                 <label>Content</label>
                 <%= textarea f, :content, class: "form-control" %>
-              < /div>
+              </div>
 
-              < div class="form-group">
+              <div class="form-group">
                 <%= submit "Add comment", class: "btn btn-primary" %>
-              < /div>
+              </div>
             <% end %>
         </xmp>
         <p>In order to render the above template in the post show view we must update it. Navigate to web => templates => post => show.html.eex and


### PR DESCRIPTION
…o a space character between the '<' and 'div' parts of of the HTML element